### PR TITLE
fixes markdown. Fix #85 Fix #84

### DIFF
--- a/core/shell/index.ejs
+++ b/core/shell/index.ejs
@@ -76,9 +76,9 @@
               exFatal: true
             })
           }
-          if (window.Raven) {
-            Raven.captureException(err)
-          }
+          // if (window.Raven) {
+          //   Raven.captureException(err)
+          // }
         } catch (e) {
           console.error(err)
           console.error(e)

--- a/src/modules/content-loader/content-loader-mixin.js
+++ b/src/modules/content-loader/content-loader-mixin.js
@@ -38,6 +38,15 @@ export default (superClass) => {
             }
           }
         })
+
+        // fix for markdown not adding a class for shady css
+        Polymer.RenderStatus.afterNextRender(this, () => {
+          this.shadowRoot.querySelectorAll('[slot=markdown-html]').forEach((item) => {
+            item.querySelectorAll('*').forEach((node) => {
+              node.classList.add(this.nodeName.toLowerCase())
+            })
+          })
+        })
       })
     }
   }


### PR DESCRIPTION
Signed-off-by: Toni-Jan Keith Monserrat <tonijanmonserrat@gmail.com>

<!-- Instructions: https://github.com/gdgphilippines/devfest/blob/master/CONTRIBUTING.md#pull-requests -->

## Issue Reference
Fixed #85 Fixed #84 

## Description
Markdown doesn't add classes on rendered elements. ShadyCSS (which is being used in Firefox and Edge) needs classes involved. Quick fix for now.

<!-- @mentions people from the team who you would like to check this pull request -->