### PR TITLE
fixed for edge

### DIFF
--- a/src/modules/devfest-module/styles/components/section.scss
+++ b/src/modules/devfest-module/styles/components/section.scss
@@ -16,11 +16,6 @@
     @apply --layout-horizontal;
     @apply --layout-wrap;
   }
-
-  iron-icon {
-    --iron-icon-height: 96px;
-    --iron-icon-width: 96px;
-  }
 }
 
 .blue.section {
@@ -30,4 +25,14 @@
 
 .gray.section {
   background-color: #fafafa;
+}
+
+.section iron-icon {
+  height: 96px;
+  width: 96px;
+}
+
+.section iron-icon {
+  --iron-icon-height: 96px;
+  --iron-icon-width: 96px;
 }


### PR DESCRIPTION
Signed-off-by: Toni-Jan Keith Monserrat <tonijanmonserrat@gmail.com>

<!-- Instructions: https://github.com/gdgphilippines/devfest/blob/master/CONTRIBUTING.md#pull-requests -->

## Issue Reference
Fixes #108 icon size for Edge 14 below (will test for IE 11 when I get to have browserstack)
<!-- Example: (For a single issue) Fixes #20 -->
<!-- Example: (For multiple issues) Fixes #32, fixes #40 -->

## Description
<!-- Example: This fixes #20 by removing styles that leaked which would cause the page to turn pink whenever `paper-foo` is clicked. -->

<!-- @mentions people from the team who you would like to check this pull request -->